### PR TITLE
Allow to pass dealroom_id and final_url

### DIFF
--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -292,11 +292,10 @@ def set_history_doc_refs(
     # CREATE: If there are not available documents in history
     elif len(history_refs) == 0:
         # Add any default values to the payload
-        _payload = {
-            "dealroom_id": _NOT_IN_DEALROOM_ENTITY_ID,
-            "final_url": "",
-            **payload,
-        }
+        if "dealroom_id" not in _payload:
+            _payload["dealroom_id"] = _NOT_IN_DEALROOM_ENTITY_ID
+        if "final_url" not in _payload:
+            _payload["final_url"] = ""
         # Validate that the new document will have the minimum required fields
         try:
             _validate_new_history_doc_payload(_payload)


### PR DESCRIPTION
There is a use case we might have missed. In particular, we should be able to pass `final_url` and `dealroom_id` to new documents to set in `history`. For example, when reading a BQ table from the backend to perform a job creator task containing companies not yet present in firestore.