### PR TITLE
DN-656: Update get_history_doc_refs to also query current_related_urls

### DIFF
--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -181,11 +181,7 @@ def get_history_doc_refs(db: firestore.Client, websiteurl_or_dealroomid: str):
     """
 
     collection_ref = db.collection(HISTORY_COLLECTION_PATH)
-    result = {
-        "dealroom_id": [],
-        "final_url": [],
-        "current_related_urls": [],
-    }
+    result = {}
 
     if str(websiteurl_or_dealroomid).isnumeric():
         query_params = ["dealroom_id", "==", int(websiteurl_or_dealroomid)]


### PR DESCRIPTION
In the case where a website is sent to search inside _history_ we will now query both final_url and current_related_urls but we can only perform a logical OR of these two queries by calling two different queries and merge them (https://firebase.google.com/docs/firestore/query-data/queries#query_limitations).