### PR TITLE
DN-855: Automate the last_edit field for history documents

### DIFF
--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -13,6 +13,7 @@ from google.cloud.firestore_v1.document import DocumentReference
 from .batch import Batcher
 from .helpers import error_logger
 from .status_codes import ERROR, SUCCESS, CREATED, UPDATED
+from datetime import datetime
 
 # Time to sleep in seconds when a exception occurrs until retrying
 EXCEPTION_SLEEP_TIME = 5
@@ -59,9 +60,24 @@ def get(doc_ref, *args, **kwargs):
             __log_exception(3, doc_ref, identifier, True)
             return ERROR
 
+def _update_last_edit(doc_ref):
+    """If the document reference points to the history collection
+    then update its "last_edit" field to the currrent datetime. This
+    datetame is parsed as a Timestamp in the document.
+
+    Args:
+        doc_ref: Firestore object reference to the document
+    """
+    _path = doc_ref.path.split("/", 1)
+    if len(_path) > 1 and _path[0] == "history":
+        doc_ref.update({"last_edit": datetime.now()})
 
 def set(doc_ref, *args, **kwargs):
     """Create a new document in Firestore
+
+    If the document is inside the "history" collection also create
+    the "last_edit" timestamp field.
+
     Args:
         doc_ref (object): Firestore reference to the document that will be created.
     Returns:
@@ -70,6 +86,7 @@ def set(doc_ref, *args, **kwargs):
     """
     try:
         doc_ref.set(*args, **kwargs, merge=True)
+        _update_last_edit(doc_ref)
         return SUCCESS
     except Exception as identifier:
         # log error
@@ -79,6 +96,7 @@ def set(doc_ref, *args, **kwargs):
         try:
             # Retry
             doc_ref.set(*args, **kwargs, merge=True)
+            _update_last_edit(doc_ref)
             return SUCCESS
         except Exception as identifier:
             # log error
@@ -96,6 +114,7 @@ def update(doc_ref, *args, **kwargs):
     """
     try:
         doc_ref.update(*args, **kwargs)
+        _update_last_edit(doc_ref)
         return SUCCESS
     except Exception as identifier:
         # log error
@@ -105,6 +124,7 @@ def update(doc_ref, *args, **kwargs):
         try:
             # Retry
             doc_ref.update(*args, **kwargs)
+            _update_last_edit(doc_ref)
             return SUCCESS
         except Exception as identifier:
             # log error

--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -13,7 +13,7 @@ from google.cloud.firestore_v1.document import DocumentReference
 from .batch import Batcher
 from .helpers import error_logger
 from .status_codes import ERROR, SUCCESS, CREATED, UPDATED
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Time to sleep in seconds when a exception occurrs until retrying
 EXCEPTION_SLEEP_TIME = 5
@@ -70,7 +70,7 @@ def _update_last_edit(doc_ref):
     """
     _path = doc_ref.path.split("/")
     if len(_path) == 2 and _path[0] == "history":
-        doc_ref.update({"last_edit": datetime.now()})
+        doc_ref.update({"last_edit": datetime.now(timezone.utc)})
 
 def set(doc_ref, *args, **kwargs):
     """Create a new document in Firestore

--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -68,8 +68,8 @@ def _update_last_edit(doc_ref):
     Args:
         doc_ref: Firestore object reference to the document
     """
-    _path = doc_ref.path.split("/", 1)
-    if len(_path) > 1 and _path[0] == "history":
+    _path = doc_ref.path.split("/")
+    if len(_path) == 2 and _path[0] == "history":
         doc_ref.update({"last_edit": datetime.now()})
 
 def set(doc_ref, *args, **kwargs):

--- a/dealroom_firestore_connector/batch.py
+++ b/dealroom_firestore_connector/batch.py
@@ -63,8 +63,8 @@ class Batcher(firestore.WriteBatch):
         Args:
             doc_ref ([type]): [description]
         """
-        _path = doc_ref.path.split("/", 1)
-        if len(_path) > 1 and _path[0] == "history":
+        _path = doc_ref.path.split("/")
+        if len(_path) == 2 and _path[0] == "history":
             self._update_last_edit(doc_ref)
 
     @_count_write

--- a/dealroom_firestore_connector/batch.py
+++ b/dealroom_firestore_connector/batch.py
@@ -7,7 +7,7 @@ from google.cloud import firestore
 
 from .helpers import error_logger
 from .status_codes import ERROR, SUCCESS
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Batcher(firestore.WriteBatch):
@@ -53,7 +53,7 @@ class Batcher(firestore.WriteBatch):
 
     @_count_write
     def _update_last_edit(self, doc_ref):
-        super().update(doc_ref, {"last_edit": datetime.now()})
+        super().update(doc_ref, {"last_edit": datetime.now(timezone.utc)})
     
     def _check_if_update_last_edit(self, doc_ref):
         """If the document reference points to the history collection


### PR DESCRIPTION
History documents should always have a `last_edit` Timestamp field. Anytime an update or set function is used then this field has to be automatically updated.

I used `datetime.now()` due to the problems we saw last Friday when using `firestore.SERVER_TIMESTAMP`.

This update should occur only for documents inside the history collection and not for things like:
`db.collection("test").document("0").collection("history").document("0")`