### PR TITLE
DN-942: Update fc set_history_doc_refs to work when matching by dealroom_id_old

### DIFF
--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -375,7 +375,7 @@ def set_history_doc_refs(
 
     if history_refs == ERROR:
         return ERROR
-    if "dealroom_id" in history_refs:
+    if "dealroom_id" in history_refs and len(history_refs["dealroom_id"]) > 0:
         count_history_refs = len(history_refs["dealroom_id"])
         key_found = "dealroom_id"
     elif "dealroom_id_old" in history_refs:
@@ -389,6 +389,9 @@ def set_history_doc_refs(
     elif "current_related_urls" in history_refs and len(history_refs["current_related_urls"]) > 0:
         count_history_refs = len(history_refs["current_related_urls"])
         key_found = "current_related_urls"
+    elif "dealroom_id_old" in history_refs and len(history_refs["dealroom_id_old"]) > 0:
+        count_history_refs = len(history_refs["dealroom_id_old"])
+        key_found = "dealroom_id_old"
     else:
         count_history_refs = 0
     # CREATE: If there are not available documents in history

--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -378,20 +378,15 @@ def set_history_doc_refs(
     if "dealroom_id" in history_refs and len(history_refs["dealroom_id"]) > 0:
         count_history_refs = len(history_refs["dealroom_id"])
         key_found = "dealroom_id"
-    elif "dealroom_id_old" in history_refs:
-        # we found a matching document but we're trying to update an entity that was removed
-        #TODO: raise a Custom Exception (DeletedEntityException)
-        logging.error("Trying to update a deleted entity.")
-        return ERROR
+    elif "dealroom_id_old" in history_refs and len(history_refs["dealroom_id_old"]) > 0:
+        count_history_refs = len(history_refs["dealroom_id_old"])
+        key_found = "dealroom_id_old"
     elif "final_url" in history_refs and len(history_refs["final_url"]) > 0:
         count_history_refs = len(history_refs["final_url"])
         key_found = "final_url"
     elif "current_related_urls" in history_refs and len(history_refs["current_related_urls"]) > 0:
         count_history_refs = len(history_refs["current_related_urls"])
         key_found = "current_related_urls"
-    elif "dealroom_id_old" in history_refs and len(history_refs["dealroom_id_old"]) > 0:
-        count_history_refs = len(history_refs["dealroom_id_old"])
-        key_found = "dealroom_id_old"
     else:
         count_history_refs = 0
     # CREATE: If there are not available documents in history


### PR DESCRIPTION
The new deleted dealroom id value (dealroom_id_old) can be used by db connector to update entities that were removed from the app, so we should consider this.