### PR TITLE
DS2-154: History document syncing overwrites document of deleted entity when a company with same final_url is created

### DIFF
--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -415,9 +415,7 @@ def check_for_deleted_profiles(
     for doc_ref in doc_refs:
         doc = doc_ref.get().to_dict()
         is_a_deleted_entity = doc["dealroom_id"] == _DELETED_DEALROOM_ENTITY_ID
-        dealroom_id_was_already_used = (
-            "dealroom_id_old" in doc and doc["dealroom_id_old"] == dealroom_id
-        )
+        dealroom_id_was_already_used = doc.get("dealroom_id_old") == dealroom_id
         if (
             is_a_deleted_entity
             and dealroom_id > 0

--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -408,11 +408,11 @@ def _get_final_url_and_dealroom_id(
 
 
 def check_for_deleted_profiles(
-    key_found, history_refs, dealroom_id, count_history_refs
+    doc_refs, dealroom_id, count_history_refs
 ):
     # https://dealroom.atlassian.net/browse/DS2-154
     # check all matching docs
-    for doc_ref in history_refs[key_found]:
+    for doc_ref in doc_refs:
         doc = doc_ref.get().to_dict()
         is_a_deleted_entity = doc["dealroom_id"] == _DELETED_DEALROOM_ENTITY_ID
         dealroom_id_was_already_used = (
@@ -485,7 +485,7 @@ def set_history_doc_refs(
     document_matches_by_final_url = key_found == "final_url"
     if document_matches_by_final_url:
         count_history_refs = check_for_deleted_profiles(
-            key_found, history_refs, dealroom_id, count_history_refs
+            history_refs[key_found], dealroom_id, count_history_refs
         )
 
     # CREATE: If there are not available documents in history

--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -407,6 +407,31 @@ def _get_final_url_and_dealroom_id(
     return final_url, dealroom_id
 
 
+def check_for_deleted_profiles(
+    key_found, history_refs, dealroom_id, count_history_refs
+):
+    # https://dealroom.atlassian.net/browse/DS2-154
+    document_matches_by_final_url = key_found == "final_url"
+    if document_matches_by_final_url:
+        # check all matching docs
+        for doc_ref in history_refs[key_found]:
+            doc = doc_ref.get().to_dict()
+            is_a_deleted_entity = doc["dealroom_id"] == _DELETED_DEALROOM_ENTITY_ID
+            dealroom_id_was_already_used = (
+                "dealroom_id_old" in doc and doc["dealroom_id_old"] == dealroom_id
+            )
+            if (
+                is_a_deleted_entity
+                and dealroom_id > 0
+                and not dealroom_id_was_already_used
+            ):
+                # Substract 1 meaning that for the current doc matching this final_url, it was deleted
+                # but this is a new company. In other words, the dealroom id for this company was never
+                # present in the history collection.
+                count_history_refs -= 1
+    return count_history_refs
+
+
 def set_history_doc_refs(
     db: firestore.Client, payload: dict, finalurl_or_dealroomid: str = None
 ) -> None:
@@ -457,6 +482,11 @@ def set_history_doc_refs(
         key_found = "current_related_urls"
     else:
         count_history_refs = 0
+
+    if count_history_refs:
+        count_history_refs = check_for_deleted_profiles(
+            key_found, history_refs, dealroom_id, count_history_refs
+        )
 
     # CREATE: If there are not available documents in history
     if count_history_refs == 0:

--- a/dealroom_firestore_connector/__init__.py
+++ b/dealroom_firestore_connector/__init__.py
@@ -411,24 +411,22 @@ def check_for_deleted_profiles(
     key_found, history_refs, dealroom_id, count_history_refs
 ):
     # https://dealroom.atlassian.net/browse/DS2-154
-    document_matches_by_final_url = key_found == "final_url"
-    if document_matches_by_final_url:
-        # check all matching docs
-        for doc_ref in history_refs[key_found]:
-            doc = doc_ref.get().to_dict()
-            is_a_deleted_entity = doc["dealroom_id"] == _DELETED_DEALROOM_ENTITY_ID
-            dealroom_id_was_already_used = (
-                "dealroom_id_old" in doc and doc["dealroom_id_old"] == dealroom_id
-            )
-            if (
-                is_a_deleted_entity
-                and dealroom_id > 0
-                and not dealroom_id_was_already_used
-            ):
-                # Substract 1 meaning that for the current doc matching this final_url, it was deleted
-                # but this is a new company. In other words, the dealroom id for this company was never
-                # present in the history collection.
-                count_history_refs -= 1
+    # check all matching docs
+    for doc_ref in history_refs[key_found]:
+        doc = doc_ref.get().to_dict()
+        is_a_deleted_entity = doc["dealroom_id"] == _DELETED_DEALROOM_ENTITY_ID
+        dealroom_id_was_already_used = (
+            "dealroom_id_old" in doc and doc["dealroom_id_old"] == dealroom_id
+        )
+        if (
+            is_a_deleted_entity
+            and dealroom_id > 0
+            and not dealroom_id_was_already_used
+        ):
+            # Substract 1 meaning that for the current doc matching this final_url, it was deleted
+            # but this is a new company. In other words, the dealroom id for this company was never
+            # present in the history collection.
+            count_history_refs -= 1
     return count_history_refs
 
 
@@ -461,6 +459,7 @@ def set_history_doc_refs(
     history_refs = get_history_doc_refs(db, final_url, dealroom_id)
 
     operation_status_code = ERROR
+    key_found = None
 
     if history_refs == ERROR:
         # TODO: raise Custom Exception (DN-932: https://dealroom.atlassian.net/browse/DN-932)
@@ -483,7 +482,8 @@ def set_history_doc_refs(
     else:
         count_history_refs = 0
 
-    if count_history_refs:
+    document_matches_by_final_url = key_found == "final_url"
+    if document_matches_by_final_url:
         count_history_refs = check_for_deleted_profiles(
             key_found, history_refs, dealroom_id, count_history_refs
         )


### PR DESCRIPTION
Fixed bug.
If we want to add a company with the same final_url as another that was previously deleted. We need to check that the dealroom_id is different and add a NEW document.